### PR TITLE
Fixed deprecation error thrown by Express 4.x.x

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,12 +1,13 @@
 var _ = require('underscore');
 var Controller = require('controller');
 var express = require('express');
+var bodyParser = require('body-parser');
 var join = require('path').join;
 var naan = require('naan');
 var async = require('async');
 
-var parserJson = naan.curry(express.json, { strict: false });
-var parserUrlEncoded = naan.curry(express.urlencoded, { strict: false });
+var parserJson = naan.curry(bodyParser.json, { strict: false });
+var parserUrlEncoded = naan.curry(bodyParser.urlencoded, { strict: false });
 
 module.exports = function(model, opts) {
   var controller = Controller();


### PR DESCRIPTION
Fixed deprecation error thrown by Express 4.x.x when trying to use the (deprecated) JSON and URLencoded parsers.
